### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ selected-model		 | no		| It exports selected model to controller variable. selec
 resize		 		 | no		| *default: true*. Use column resizing.
 drag-columns		 | no		| *default: false*. It allows to reorder your columns using drag-n-drop.
 
-##Themes
+## Themes
 Please check new 'Dark-sky' and 'Blue-dust' themes:
 http://ekokotov.github.io/object-table/samples.html#/themes
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
